### PR TITLE
Fix for Dialogues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ playground.xcworkspace
 
 # Other
 *.orig
+
+# Theos
+.theos/
+.theos-cache/
+.theos-cache-*/
+.theos-cache-*/

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,4 @@ ifneq ($(JAILBROKEN),1)
 include $(THEOS_MAKE_PATH)/aggregate.mk
 endif
 include $(THEOS_MAKE_PATH)/tweak.mk
+include $(THEOS_MAKE_PATH)/bundle.mk

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,23 @@ endif
 INSTALL_TARGET_PROCESSES = FGame
 TWEAK_NAME = FFXIVM-en-patch
 
+# 🔽 Define the bundle details
+BUNDLE_NAME = FFXIVMBundle
+$(TWEAK_NAME)_BUNDLE = $(BUNDLE_NAME)
+
+# For jailbroken devices, install to system path
+ifeq ($(JAILBROKEN),1)
+$(BUNDLE_NAME)_INSTALL_PATH = /Library/Application Support/FFXIVM-en-patch
+else
+# For sideloaded apps, include bundle in the main app bundle
+$(TWEAK_NAME)_BUNDLES = $(BUNDLE_NAME)
+endif
+
+$(BUNDLE_NAME)_RESOURCE_FILES = Resources/*
+
 $(TWEAK_NAME)_FILES := $(wildcard src/*.xm)
 $(TWEAK_NAME)_CFLAGS = -fobjc-arc -Wno-module-import-in-extern-c
+$(TWEAK_NAME)_FRAMEWORKS = UIKit
 
 include $(THEOS)/makefiles/common.mk
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" 
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.und3fined.ffxivm-bundle</string>
+    <key>CFBundleName</key>
+    <string>FFXIVMBundle</string>
+</dict>
+</plist>

--- a/src/DialogueFix.h
+++ b/src/DialogueFix.h
@@ -5,4 +5,11 @@
 void dialogueFix(void);
 
 // Helper function to write to log file
-void writeToLogFile(NSString *message); 
+void writeToLogFile(NSString *message);
+
+// File permission management functions
+BOOL setFileReadOnly(NSString *filePath);
+BOOL restoreFileWritePermissions(NSString *filePath);
+BOOL setFileImmutable(NSString *filePath);
+BOOL removeFileImmutable(NSString *filePath);
+BOOL isFileProtected(NSString *filePath); 

--- a/src/DialogueFix.h
+++ b/src/DialogueFix.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+// Function to fix dialogue issues by copying database file
+void dialogueFix(void);
+
+// Helper function to write to log file
+void writeToLogFile(NSString *message); 

--- a/src/DialogueFix.xm
+++ b/src/DialogueFix.xm
@@ -1,0 +1,144 @@
+#import "DialogueFix.h"
+#import "FileMonitoring.h"
+
+// Helper function to write to log file in Documents directory
+void writeToLogFile(NSString *message) {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  NSURL *documentsURL = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+  NSString *documentsDirectory = [documentsURL path];
+  NSString *logPath = [documentsDirectory stringByAppendingPathComponent:@"FFXIVM.log"];
+
+  // Timestamp
+  NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+  [formatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
+  NSString *timestamp = [formatter stringFromDate:[NSDate date]];
+  NSString *logMessage = [NSString stringWithFormat:@"[%@] %@\n", timestamp, message];
+
+  // Append to file
+  NSFileHandle *fileHandle = [NSFileHandle fileHandleForWritingAtPath:logPath];
+  if (fileHandle) {
+    [fileHandle seekToEndOfFile];
+    [fileHandle writeData:[logMessage dataUsingEncoding:NSUTF8StringEncoding]];
+    [fileHandle closeFile];
+  } else {
+    [logMessage writeToFile:logPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+  }
+}
+
+// Dialogues were broken with 1.0.2.12
+void dialogueFix() {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+
+  NSURL *documentsURL = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+  NSString *documentsDirectory = [documentsURL path];
+
+  // Define source and destination paths for the bundle
+  // For sideloaded apps, look in the main app bundle first, then fallback to system path
+  NSString *bundlePath = nil;
+  NSBundle *bundle = nil;
+  
+  // Try to find the bundle in the main app bundle (for sideloaded apps)
+  NSBundle *mainBundle = [NSBundle mainBundle];
+  NSString *mainBundlePath = [mainBundle pathForResource:@"FFXIVMBundle" ofType:@"bundle"];
+  if (mainBundlePath) {
+    bundlePath = mainBundlePath;
+    bundle = [NSBundle bundleWithPath:bundlePath];
+    writeToLogFile([NSString stringWithFormat:@"[INFO] Found bundle in main app bundle: %@", bundlePath]);
+  } else {
+    // Fallback to system path (for jailbroken devices)
+    bundlePath = @"/Library/Application Support/FFXIVM-en-patch/FFXIVMBundle.bundle";
+    bundle = [NSBundle bundleWithPath:bundlePath];
+    if (!bundle) {
+      // Try the old path as final fallback
+      bundlePath = @"/Library/MobileSubstrate/DynamicLibraries/FFXIVMBundle.bundle";
+      bundle = [NSBundle bundleWithPath:bundlePath];
+    }
+    writeToLogFile([NSString stringWithFormat:@"[INFO] Using system bundle path: %@", bundlePath]);
+  }
+
+  if (!bundle) {
+    writeToLogFile([NSString stringWithFormat:@"[ERROR] Failed to create bundle from path: %@", bundlePath]);
+    return;
+  }
+
+  // For system bundles (jailbroken), try to load. For app bundles (sideloaded), just use directly
+  if (!mainBundlePath && ![bundle load]) {
+    writeToLogFile([NSString stringWithFormat:@"[ERROR] Failed to load FFXIVM bundle from %@", bundlePath]);
+    return;
+  }
+
+  // Retrieve the database file path from the bundle
+  NSString *databasePath = [bundle pathForResource:@"FDataBaseLoc" ofType:@"db"];
+  if (!databasePath || ![fileManager fileExistsAtPath:databasePath]) {
+    writeToLogFile(@"[ERROR] FFXIVM Database file not found in bundle Resources");
+    return;
+  }
+
+  // Prepare the destination path inside the app's FGame directory
+  NSString *dbDestinationDir = [documentsDirectory stringByAppendingPathComponent:@"FGame/PersistentDownloadDir/Database"];
+  BOOL isDirectory = NO;
+  if (![fileManager fileExistsAtPath:dbDestinationDir isDirectory:&isDirectory] || !isDirectory) {
+    NSError *dirError = nil;
+    [fileManager createDirectoryAtPath:dbDestinationDir withIntermediateDirectories:YES attributes:nil error:&dirError];
+    if (dirError) {
+      writeToLogFile([NSString stringWithFormat:@"[ERROR] Failed to create database directory: %@", dirError.localizedDescription]);
+      return;
+    }
+    writeToLogFile([NSString stringWithFormat:@"[INFO] Created database directory: %@", dbDestinationDir]);
+  }
+
+  // Final destination file 
+  NSString *destFilePath = [dbDestinationDir stringByAppendingPathComponent:@"FDataBaseLoc.db"];
+  writeToLogFile([NSString stringWithFormat:@"[INFO] Copying database from %@ to %@", databasePath, destFilePath]);
+
+  // Use a more robust file replacement approach
+  NSError *replacementError = nil;
+  BOOL fileExists = [fileManager fileExistsAtPath:destFilePath];
+  
+  if (fileExists) {
+    writeToLogFile([NSString stringWithFormat:@"[INFO] Existing database found, replacing: %@", destFilePath]);
+    
+    // Try to use replaceItemAtURL for atomic replacement (iOS 4.0+)
+    NSURL *sourceURL = [NSURL fileURLWithPath:databasePath];
+    NSURL *destURL = [NSURL fileURLWithPath:destFilePath];
+    
+    NSURL *resultingURL = nil;
+    if ([fileManager replaceItemAtURL:destURL withItemAtURL:sourceURL backupItemName:nil options:NSFileManagerItemReplacementUsingNewMetadataOnly resultingItemURL:&resultingURL error:&replacementError]) {
+      writeToLogFile(@"[INFO] Successfully replaced existing database using atomic replacement");
+      
+      // Setup file monitoring
+      setupFileMonitoring(databasePath, destFilePath);
+    } else {
+      writeToLogFile([NSString stringWithFormat:@"[WARN] Atomic replacement failed: %@, trying manual replacement", replacementError.localizedDescription]);
+      
+      // Fallback to manual remove and copy
+      if ([fileManager removeItemAtPath:destFilePath error:&replacementError]) {
+        writeToLogFile(@"[INFO] Successfully removed existing database");
+        
+        // Now copy the new file
+        if ([fileManager copyItemAtPath:databasePath toPath:destFilePath error:&replacementError]) {
+          writeToLogFile(@"[INFO] Successfully copied new database after manual removal");
+          
+          // Setup file monitoring
+          setupFileMonitoring(databasePath, destFilePath);
+        } else {
+          writeToLogFile([NSString stringWithFormat:@"[ERROR] Failed to copy database after removal: %@", replacementError.localizedDescription]);
+        }
+      } else {
+        writeToLogFile([NSString stringWithFormat:@"[ERROR] Failed to remove existing database: %@", replacementError.localizedDescription]);
+      }
+    }
+  } else {
+    writeToLogFile(@"[INFO] No existing database found, creating new one");
+    
+    // No existing file, just copy
+    if ([fileManager copyItemAtPath:databasePath toPath:destFilePath error:&replacementError]) {
+      writeToLogFile(@"[INFO] Successfully copied new database");
+      
+      // Setup file monitoring
+      setupFileMonitoring(databasePath, destFilePath);
+    } else {
+      writeToLogFile([NSString stringWithFormat:@"[ERROR] Failed to copy database: %@", replacementError.localizedDescription]);
+    }
+  }
+} 

--- a/src/DialogueFix.xm
+++ b/src/DialogueFix.xm
@@ -1,5 +1,8 @@
 #import "DialogueFix.h"
 #import "FileMonitoring.h"
+#import <sys/stat.h>
+#import <sys/attr.h>
+#import <errno.h>
 
 // Helper function to write to log file in Documents directory
 void writeToLogFile(NSString *message) {
@@ -23,6 +26,152 @@ void writeToLogFile(NSString *message) {
   } else {
     [logMessage writeToFile:logPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
   }
+}
+
+// Helper function to set file permissions to read-only
+BOOL setFileReadOnly(NSString *filePath) {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  
+  if (![fileManager fileExistsAtPath:filePath]) {
+    writeToLogFile([NSString stringWithFormat:@"[PERM] File does not exist: %@", filePath]);
+    return NO;
+  }
+  
+  NSError *error = nil;
+  NSDictionary *attributes = [fileManager attributesOfItemAtPath:filePath error:&error];
+  if (error) {
+    writeToLogFile([NSString stringWithFormat:@"[PERM] Failed to get file attributes: %@", error.localizedDescription]);
+    return NO;
+  }
+  
+  // Get current permissions
+  NSNumber *permissions = [attributes objectForKey:NSFilePosixPermissions];
+  NSInteger currentPerms = [permissions integerValue];
+  
+  // Remove write permissions for owner, group, and others (0444)
+  NSInteger readOnlyPerms = currentPerms & ~(S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+  readOnlyPerms |= S_IRUSR | S_IRGRP | S_IROTH; // Set read permissions for all
+  
+  // Set the new permissions
+  NSDictionary *newAttributes = @{NSFilePosixPermissions: @(readOnlyPerms)};
+  if ([fileManager setAttributes:newAttributes ofItemAtPath:filePath error:&error]) {
+    writeToLogFile([NSString stringWithFormat:@"[PERM] Successfully set read-only permissions on: %@", filePath]);
+    return YES;
+  } else {
+    writeToLogFile([NSString stringWithFormat:@"[PERM] Failed to set read-only permissions: %@", error.localizedDescription]);
+    return NO;
+  }
+}
+
+// Helper function to restore write permissions (for when we need to update the file)
+BOOL restoreFileWritePermissions(NSString *filePath) {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  
+  if (![fileManager fileExistsAtPath:filePath]) {
+    writeToLogFile([NSString stringWithFormat:@"[PERM] File does not exist: %@", filePath]);
+    return NO;
+  }
+  
+  NSError *error = nil;
+  NSDictionary *attributes = [fileManager attributesOfItemAtPath:filePath error:&error];
+  if (error) {
+    writeToLogFile([NSString stringWithFormat:@"[PERM] Failed to get file attributes: %@", error.localizedDescription]);
+    return NO;
+  }
+  
+  // Get current permissions
+  NSNumber *permissions = [attributes objectForKey:NSFilePosixPermissions];
+  NSInteger currentPerms = [permissions integerValue];
+  
+  // Add write permissions for owner (0644)
+  NSInteger writePerms = currentPerms | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+  
+  // Set the new permissions
+  NSDictionary *newAttributes = @{NSFilePosixPermissions: @(writePerms)};
+  if ([fileManager setAttributes:newAttributes ofItemAtPath:filePath error:&error]) {
+    writeToLogFile([NSString stringWithFormat:@"[PERM] Successfully restored write permissions on: %@", filePath]);
+    return YES;
+  } else {
+    writeToLogFile([NSString stringWithFormat:@"[PERM] Failed to restore write permissions: %@", error.localizedDescription]);
+    return NO;
+  }
+}
+
+// Helper function to make file immutable (chattr +i equivalent)
+BOOL setFileImmutable(NSString *filePath) {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  
+  if (![fileManager fileExistsAtPath:filePath]) {
+    writeToLogFile([NSString stringWithFormat:@"[IMMUTABLE] File does not exist: %@", filePath]);
+    return NO;
+  }
+  
+  // Try to set the immutable flag using system call
+  const char *path = [filePath UTF8String];
+  int result = chflags(path, UF_IMMUTABLE);
+  
+  if (result == 0) {
+    writeToLogFile([NSString stringWithFormat:@"[IMMUTABLE] Successfully set immutable flag on: %@", filePath]);
+    return YES;
+  } else {
+    writeToLogFile([NSString stringWithFormat:@"[IMMUTABLE] Failed to set immutable flag: %s", strerror(errno)]);
+    return NO;
+  }
+}
+
+// Helper function to remove immutable flag
+BOOL removeFileImmutable(NSString *filePath) {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  
+  if (![fileManager fileExistsAtPath:filePath]) {
+    writeToLogFile([NSString stringWithFormat:@"[IMMUTABLE] File does not exist: %@", filePath]);
+    return NO;
+  }
+  
+  // Try to remove the immutable flag using system call
+  const char *path = [filePath UTF8String];
+  int result = chflags(path, 0);
+  
+  if (result == 0) {
+    writeToLogFile([NSString stringWithFormat:@"[IMMUTABLE] Successfully removed immutable flag from: %@", filePath]);
+    return YES;
+  } else {
+    writeToLogFile([NSString stringWithFormat:@"[IMMUTABLE] Failed to remove immutable flag: %s", strerror(errno)]);
+    return NO;
+  }
+}
+
+// Helper function to check if file is protected (immutable or read-only)
+BOOL isFileProtected(NSString *filePath) {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  
+  if (![fileManager fileExistsAtPath:filePath]) {
+    return NO;
+  }
+  
+  NSError *error = nil;
+  NSDictionary *attributes = [fileManager attributesOfItemAtPath:filePath error:&error];
+  if (error) {
+    return NO;
+  }
+  
+  // Check for immutable flag
+  NSNumber *flags = [attributes objectForKey:NSFileImmutable];
+  if (flags && [flags boolValue]) {
+    return YES;
+  }
+  
+  // Check for read-only permissions
+  NSNumber *permissions = [attributes objectForKey:NSFilePosixPermissions];
+  if (permissions) {
+    NSInteger perms = [permissions integerValue];
+    // Check if write permissions are missing for owner
+    if (!(perms & S_IWUSR)) {
+      return YES;
+    }
+  }
+  
+  return NO;
 }
 
 // Dialogues were broken with 1.0.2.12
@@ -91,9 +240,25 @@ void dialogueFix() {
   NSString *destFilePath = [dbDestinationDir stringByAppendingPathComponent:@"FDataBaseLoc.db"];
   writeToLogFile([NSString stringWithFormat:@"[INFO] Copying database from %@ to %@", databasePath, destFilePath]);
 
+
+  //also delete FDataBase.db if it exists
+
+  NSString *fDataBasePath = [dbDestinationDir stringByAppendingPathComponent:@"FDataBase.db"];
+  if ([fileManager fileExistsAtPath:fDataBasePath]) {
+    NSError *deleteError = nil;
+    if ([fileManager removeItemAtPath:fDataBasePath error:&deleteError]) {
+      writeToLogFile(@"[INFO] Successfully deleted FDataBase.db on first run");
+    } else {
+      writeToLogFile([NSString stringWithFormat:@"[WARN] Failed to delete FDataBase.db: %@", deleteError.localizedDescription]);
+    }
+  } else {
+    writeToLogFile(@"[INFO] FDataBase.db not found, skipping deletion");
+  }
+
   // Use a more robust file replacement approach
   NSError *replacementError = nil;
   BOOL fileExists = [fileManager fileExistsAtPath:destFilePath];
+  BOOL fileCopied = NO;
   
   if (fileExists) {
     writeToLogFile([NSString stringWithFormat:@"[INFO] Existing database found, replacing: %@", destFilePath]);
@@ -105,9 +270,7 @@ void dialogueFix() {
     NSURL *resultingURL = nil;
     if ([fileManager replaceItemAtURL:destURL withItemAtURL:sourceURL backupItemName:nil options:NSFileManagerItemReplacementUsingNewMetadataOnly resultingItemURL:&resultingURL error:&replacementError]) {
       writeToLogFile(@"[INFO] Successfully replaced existing database using atomic replacement");
-      
-      // Setup file monitoring
-      setupFileMonitoring(databasePath, destFilePath);
+      fileCopied = YES;
     } else {
       writeToLogFile([NSString stringWithFormat:@"[WARN] Atomic replacement failed: %@, trying manual replacement", replacementError.localizedDescription]);
       
@@ -118,9 +281,7 @@ void dialogueFix() {
         // Now copy the new file
         if ([fileManager copyItemAtPath:databasePath toPath:destFilePath error:&replacementError]) {
           writeToLogFile(@"[INFO] Successfully copied new database after manual removal");
-          
-          // Setup file monitoring
-          setupFileMonitoring(databasePath, destFilePath);
+          fileCopied = YES;
         } else {
           writeToLogFile([NSString stringWithFormat:@"[ERROR] Failed to copy database after removal: %@", replacementError.localizedDescription]);
         }
@@ -134,11 +295,37 @@ void dialogueFix() {
     // No existing file, just copy
     if ([fileManager copyItemAtPath:databasePath toPath:destFilePath error:&replacementError]) {
       writeToLogFile(@"[INFO] Successfully copied new database");
-      
-      // Setup file monitoring
-      setupFileMonitoring(databasePath, destFilePath);
+      fileCopied = YES;
     } else {
       writeToLogFile([NSString stringWithFormat:@"[ERROR] Failed to copy database: %@", replacementError.localizedDescription]);
     }
+  }
+  
+  // If file was successfully copied, set permissions to prevent overwriting
+  if (fileCopied) {
+    writeToLogFile(@"[INFO] Setting file permissions to prevent overwriting");
+    
+    // First try to set immutable flag (strongest protection)
+    if (setFileImmutable(destFilePath)) {
+      writeToLogFile(@"[INFO] Successfully set immutable flag on database file");
+    } else {
+      // Fallback to read-only permissions
+      writeToLogFile(@"[INFO] Immutable flag failed, trying read-only permissions");
+      if (setFileReadOnly(destFilePath)) {
+        writeToLogFile(@"[INFO] Successfully set read-only permissions on database file");
+      } else {
+        writeToLogFile(@"[WARN] Failed to set file permissions, relying on monitoring only");
+      }
+    }
+    
+    // Log the final protection status
+    if (isFileProtected(destFilePath)) {
+      writeToLogFile(@"[INFO] Database file is now protected from overwriting");
+    } else {
+      writeToLogFile(@"[WARN] Database file protection failed, relying on monitoring");
+    }
+    
+    // Setup file monitoring as backup
+    setupFileMonitoring(databasePath, destFilePath);
   }
 } 

--- a/src/FFXIVM.h
+++ b/src/FFXIVM.h
@@ -1,3 +1,4 @@
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #import <rootless.h>

--- a/src/FFXIVM.xm
+++ b/src/FFXIVM.xm
@@ -83,9 +83,67 @@ void removeFilePak() {
   }
 }
 
+// Dialogues were broken with 1.0.2.12
+void dialogueFix() {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  
+  // Get the documents directory
+  NSURL *documentsURL = [[fileManager URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+  NSString *documentsDirectory = [documentsURL path];
+  
+  // Get the bundle path for the database file from Resources
+  NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"FDataBaseLoc" ofType:@"db"];
+  
+  if (!bundlePath) {
+    NSLog(@"FFXIVM Database file not found in bundle Resources");
+    return;
+  }
+  
+  // Destination path in documents
+  NSString *destPath = [documentsDirectory stringByAppendingPathComponent:@"FGame/PersistentDownloadDir/Database"];
+  
+  // Create destination directory if it doesn't exist
+  BOOL isDirectory = NO;
+  if (![fileManager fileExistsAtPath:destPath isDirectory:&isDirectory] || !isDirectory) {
+    NSError *dirError = nil;
+    [fileManager createDirectoryAtPath:destPath withIntermediateDirectories:YES attributes:nil error:&dirError];
+    if (dirError) {
+      NSLog(@"FFXIVM Error creating destination directory: %@", dirError.localizedDescription);
+      return;
+    }
+  }
+  
+  NSString *destFilePath = [destPath stringByAppendingPathComponent:@"FDataBaseLoc.db"];
+  
+  NSLog(@"FFXIVM Copying database from %@ to %@", bundlePath, destFilePath);
+  
+  // Always overwrite: remove the destination file if it exists
+  if ([fileManager fileExistsAtPath:destFilePath]) {
+    NSError *removeError = nil;
+    BOOL removed = [fileManager removeItemAtPath:destFilePath error:&removeError];
+    if (!removed) {
+      NSLog(@"FFXIVM Error removing existing database: %@", removeError.localizedDescription);
+      // Optionally, return here if you don't want to proceed on failure
+    }
+  }
+  
+  // Copy the file
+  NSError *copyError = nil;
+  BOOL success = [fileManager copyItemAtPath:bundlePath toPath:destFilePath error:&copyError];
+  
+  if (success) {
+    NSLog(@"FFXIVM Successfully copied database to documents");
+  } else {
+    NSLog(@"FFXIVM Error copying database: %@", copyError.localizedDescription);
+  }
+}
+
 %ctor {
   NSLog(@"FFXIVM Initializing...");
   writeGameUserSettingsToIni();
-  removeFilePak();
   NSLog(@"FFXIVM GameUserSettings.ini written to Documents directory.");
+  removeFilePak();
+  NSLog(@"FFXIVM Language blocking Pak files removed.");
+  dialogueFix();
+  NSLog(@"FFXIVM Dialogue fix implemented.");
 }

--- a/src/FileMonitoring.h
+++ b/src/FileMonitoring.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+// Global variables for file monitoring (extern declarations)
+extern NSString *g_databaseSourcePath;
+extern NSString *g_databaseDestPath;
+extern NSTimer *g_fileMonitorTimer;
+extern NSData *g_originalFileData;
+
+// File monitoring functions
+BOOL filesAreIdentical(NSString *path1, NSString *path2);
+void restoreDatabaseFile(void);
+void startDatabaseMonitoring(void);
+void stopDatabaseMonitoring(void);
+void manualRestoreDatabase(void);
+BOOL isDatabaseMonitoringActive(void);
+
+// Setup function to initialize monitoring with paths
+void setupFileMonitoring(NSString *sourcePath, NSString *destPath);
+
+// App lifecycle monitoring setup
+void setupAppLifecycleMonitoring(void); 

--- a/src/FileMonitoring.xm
+++ b/src/FileMonitoring.xm
@@ -1,0 +1,162 @@
+#import "FileMonitoring.h"
+#import "DialogueFix.h"
+
+// Global variables for file monitoring
+NSString *g_databaseSourcePath = nil;
+NSString *g_databaseDestPath = nil;
+NSTimer *g_fileMonitorTimer = nil;
+NSData *g_originalFileData = nil;
+
+// Helper function to compare file contents
+BOOL filesAreIdentical(NSString *path1, NSString *path2) {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  
+  if (![fileManager fileExistsAtPath:path1] || ![fileManager fileExistsAtPath:path2]) {
+    return NO;
+  }
+  
+  NSData *data1 = [NSData dataWithContentsOfFile:path1];
+  NSData *data2 = [NSData dataWithContentsOfFile:path2];
+  
+  if (!data1 || !data2) {
+    return NO;
+  }
+  
+  return [data1 isEqualToData:data2];
+}
+
+// Function to restore the database file if it's been overwritten
+void restoreDatabaseFile() {
+  if (!g_databaseSourcePath || !g_databaseDestPath) {
+    return;
+  }
+  
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  
+  // Check if the destination file exists and if it's different from our source
+  if ([fileManager fileExistsAtPath:g_databaseDestPath]) {
+    if (filesAreIdentical(g_databaseSourcePath, g_databaseDestPath)) {
+      // File is correct, no need to restore
+      return;
+    }
+    
+    // File has been overwritten, restore it
+    writeToLogFile(@"[MONITOR] Database file was overwritten, restoring...");
+    
+    NSError *error = nil;
+    if ([fileManager removeItemAtPath:g_databaseDestPath error:&error]) {
+      if ([fileManager copyItemAtPath:g_databaseSourcePath toPath:g_databaseDestPath error:&error]) {
+        writeToLogFile(@"[MONITOR] Successfully restored database file");
+      } else {
+        writeToLogFile([NSString stringWithFormat:@"[MONITOR] Failed to copy restored database: %@", error.localizedDescription]);
+      }
+    } else {
+      writeToLogFile([NSString stringWithFormat:@"[MONITOR] Failed to remove overwritten database: %@", error.localizedDescription]);
+    }
+  } else {
+    // File doesn't exist at all, restore it
+    writeToLogFile(@"[MONITOR] Database file missing, restoring...");
+    
+    NSError *error = nil;
+    if ([fileManager copyItemAtPath:g_databaseSourcePath toPath:g_databaseDestPath error:&error]) {
+      writeToLogFile(@"[MONITOR] Successfully restored missing database file");
+    } else {
+      writeToLogFile([NSString stringWithFormat:@"[MONITOR] Failed to restore missing database: %@", error.localizedDescription]);
+    }
+  }
+}
+
+// Start monitoring the database file
+void startDatabaseMonitoring() {
+  if (g_fileMonitorTimer) {
+    [g_fileMonitorTimer invalidate];
+  }
+  
+  // Use a dispatch timer for better reliability
+  static dispatch_source_t timer = nil;
+  if (timer) {
+    dispatch_source_cancel(timer);
+  }
+  
+  timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, dispatch_get_main_queue());
+  if (timer) {
+    dispatch_source_set_timer(timer, dispatch_time(DISPATCH_TIME_NOW, 0), 5.0 * NSEC_PER_SEC, 0.1 * NSEC_PER_SEC);
+    dispatch_source_set_event_handler(timer, ^{
+      restoreDatabaseFile();
+    });
+    dispatch_resume(timer);
+    writeToLogFile(@"[MONITOR] Started database file monitoring (5 second intervals)");
+  } else {
+    writeToLogFile(@"[MONITOR] Failed to create monitoring timer");
+  }
+}
+
+// Stop monitoring (cleanup)
+void stopDatabaseMonitoring() {
+  if (g_fileMonitorTimer) {
+    [g_fileMonitorTimer invalidate];
+    g_fileMonitorTimer = nil;
+    writeToLogFile(@"[MONITOR] Stopped database file monitoring");
+  }
+}
+
+// Manual restore function - can be called anytime
+void manualRestoreDatabase() {
+  writeToLogFile(@"[MANUAL] Manual database restore requested");
+  restoreDatabaseFile();
+}
+
+// Check if monitoring is active
+BOOL isDatabaseMonitoringActive() {
+  return (g_databaseSourcePath != nil && g_databaseDestPath != nil);
+}
+
+// Setup function to initialize monitoring with paths
+void setupFileMonitoring(NSString *sourcePath, NSString *destPath) {
+  // Store paths for monitoring
+  g_databaseSourcePath = [sourcePath copy];
+  g_databaseDestPath = [destPath copy];
+  
+  writeToLogFile([NSString stringWithFormat:@"[MONITOR] Setup file monitoring from %@ to %@", sourcePath, destPath]);
+  
+  // Start monitoring
+  startDatabaseMonitoring();
+}
+
+// App lifecycle functions
+void setupAppLifecycleMonitoring() {
+  // Use string literals as fallback in case UIKit constants aren't available
+  NSString *didBecomeActiveNotification = @"UIApplicationDidBecomeActiveNotification";
+  NSString *willEnterForegroundNotification = @"UIApplicationWillEnterForegroundNotification";
+  NSString *didEnterBackgroundNotification = @"UIApplicationDidEnterBackgroundNotification";
+  
+  [[NSNotificationCenter defaultCenter] addObserverForName:didBecomeActiveNotification
+                                                    object:nil
+                                                     queue:[NSOperationQueue mainQueue]
+                                                usingBlock:^(NSNotification *note) {
+    writeToLogFile(@"[LIFECYCLE] App became active, checking database integrity");
+    if (g_databaseSourcePath && g_databaseDestPath) {
+      restoreDatabaseFile();
+    }
+  }];
+  
+  [[NSNotificationCenter defaultCenter] addObserverForName:willEnterForegroundNotification
+                                                    object:nil
+                                                     queue:[NSOperationQueue mainQueue]
+                                                usingBlock:^(NSNotification *note) {
+    writeToLogFile(@"[LIFECYCLE] App entering foreground, restarting monitoring");
+    if (g_databaseSourcePath && g_databaseDestPath) {
+      startDatabaseMonitoring();
+    }
+  }];
+  
+  [[NSNotificationCenter defaultCenter] addObserverForName:didEnterBackgroundNotification
+                                                    object:nil
+                                                     queue:[NSOperationQueue mainQueue]
+                                                usingBlock:^(NSNotification *note) {
+    writeToLogFile(@"[LIFECYCLE] App entering background, monitoring continues");
+    // Keep monitoring active even in background
+  }];
+  
+  writeToLogFile(@"[MONITOR] App lifecycle monitoring setup complete");
+} 


### PR DESCRIPTION
This is a pretty substantial rework. The two main things are...

- Tweaks are now placed in their separate files so that we  don't clutter up the main Tweak file. Also this way we can turn off or update feature tweaks as needed.

- Dialogues are now fixed for non EN versions of iOS after the most recent patch. To fix this, we are injecting the pre-patch db file and setting permissions on it so that the game won't overwrite the db file on each launch. We also have file monitoring on the db file just in case it get's rewritten somehow.

Please feel free to take what you like from this, remove or even reimplement as needed!